### PR TITLE
Increment version details

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -15,11 +15,11 @@
     <author>John P Kirk</author>
     <email>john@civifirst.com</email>
   </maintainer>
-  <releaseDate>2016-11-20</releaseDate>
-  <version>2.03</version>
+  <releaseDate>2019-09-12</releaseDate>
+  <version>2.1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.7</ver>
+    <ver>5.18/ver>
   </compatibility>
   <category>Data Cleaning</category>
   <comments>The email addresses were selected based on Future First's experience of common email errors.</comments>


### PR DESCRIPTION
I'm doing all my testing on 5.18 (current rc) and finding a few things broken which you'll get prs for.

I usually  think it's best to increment the supported civi version whenever you do a new piece of work on an extension as the code 'expected' to work on  earlier versions is already released & available for earlier versions & who wants to say new code works on an older version - buyer (freeloader) beware makes more sense IMHO.

This increments & then maybe it's work dropping a release once I stop throwing changes at you.